### PR TITLE
Bugfixed memory bug in Base64Encode (for SSHA encoding)

### DIFF
--- a/pam_mysql.c
+++ b/pam_mysql.c
@@ -771,19 +771,22 @@ static size_t calcDecodeLength(const char* b64input) {
 int Base64Encode(const unsigned char* buffer, size_t length, char** b64text) {
 	BIO *bio, *b64;
 	BUF_MEM *bufferPtr;
+	size_t b64len;
 
 	b64 = BIO_new(BIO_f_base64());
 	bio = BIO_new(BIO_s_mem());
 	bio = BIO_push(b64, bio);
 
 	BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL); //Ignore newlines - write everything in one line
+	BIO_set_close(bio, BIO_CLOSE);
 	BIO_write(bio, buffer, length);
 	BIO_flush(bio);
-	BIO_get_mem_ptr(bio, &bufferPtr);
-	BIO_set_close(bio, BIO_NOCLOSE);
-	BIO_free_all(bio);
 
-	*b64text=(*bufferPtr).data;
+	b64len = bufferPtr->length;
+	(*b64text) = (char *) malloc((b64len + 1) * sizeof(char));
+	memcpy(*b64text, bufferPtr->data, b64len);
+	(*b64text)[b64len] = '\0';
+	BIO_free_all(bio);
 
 	return (0); //success
 }


### PR DESCRIPTION
I have found a bug where the pointer of b64text seems to run in a memory problem under some circumances
ie. if verbose=1 all works, if verbose=0 the following correct base64 string
`/c4Me5tmpl7HzUiTtMNOV8jLbJxilvd0UhgWHw==`
is returned as
`/c4Me5tmpl7HzUiTtMNOV8jLbJxilvd0UhgWHw==ollation name="lq#023`
Very strange...
I changed the code so that it's working now...
